### PR TITLE
feat: send an execution plan automatically without additional confirmation (#11)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,8 @@ linters-settings:
   gocritic:
     enabled-tags:
       - performance
+  funlen:
+    lines: 70
 
 linters:
   enable-all: true
@@ -53,7 +55,6 @@ issues:
       linters:
         - dupl
         - gocyclo
-        - lll
         - errcheck
         - wsl
         - gomnd

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ It's highly recommended installing a specific version of the `plan-exporter` ava
 To quickly install the tool on Linux, download and decompress the binary, use an example:
 
 ```bash
-wget https://github.com/agneum/plan-exporter/releases/download/v0.0.4/plan-exporter-0.0.4-linux-amd64.tar.gz
-tar -zxvf plan-exporter-0.0.4-linux-amd64.tar.gz
+wget https://github.com/agneum/plan-exporter/releases/download/v0.0.5/plan-exporter-0.0.5-linux-amd64.tar.gz
+tar -zxvf plan-exporter-0.0.5-linux-amd64.tar.gz
 sudo mv plan-exporter-*/plan-exporter /usr/local/bin/
 rm -rf ./plan-exporter-*
 ```
@@ -40,7 +40,7 @@ On default, make install puts the compiled binary in `go/bin`.
     postgres=# \o | plan-exporter
     ```
     * You may wish to specify `--target [dalibo|depesz|tensor]` to customize your visualizer
-    * You may also specify `--post_url <URL>` if you are deploying one of these targets on-premise
+    * You may also specify `--post-url <URL>` if you are deploying one of these targets on-premise
 
 1. Run explain query:
     ```bash
@@ -78,7 +78,12 @@ On default, make install puts the compiled binary in `go/bin`.
   - `depesz` - https://explain.depesz.com [default]
   - `dalibo` - https://explain.dalibo.com
   - `tensor` - https://explain.tensor.ru
-- `--post_url` - The absolute URL to which the `<form>` will `POST` to.  A good reference would be to look for the `action` param in the `<form>` tag.
+- `--post-url`- (string, optional, default: "") - the absolute URL to which the `<form>` will `POST` to.  A good reference would be to look for the `action` param in the `<form>` tag.
+- `--auto-confirm` (bool, optional, default: false) - send an execution plan automatically without additional confirmation. 
+  The option allows using `plan-exporter` outside `psql`. For example,
+  ```bash
+  psql -f my_explain_file.sql | plan-exporter --target=dalibo --auto-confirm
+  ``` 
 
 ## Contact Information
 

--- a/main.go
+++ b/main.go
@@ -14,17 +14,16 @@ import (
 
 func main() {
 	target := flag.String("target", "depesz", "type of an explain visualizer to export")
-	postURL := flag.String("post_url", "", "Absolute URL to HTML <form> element's `action`")
+	postURL := flag.String("post-url", "", "absolute URL to HTML <form> element's `action`")
+	autoConfirm := flag.Bool("auto-confirm", false, "send an execution plan automatically without additional confirmation")
 
 	flag.Parse()
 
-	cfg := &config.Config{
+	ctx := context.Background()
+	planner, err := visualizer.New(&config.Config{
 		Target:  *target,
 		PostURL: *postURL,
-	}
-
-	ctx := context.Background()
-	planner, err := visualizer.New(cfg)
+	})
 
 	if err != nil {
 		log.Fatalf("failed to init a query plan exporter: %v", err)
@@ -32,6 +31,10 @@ func main() {
 
 	fmt.Printf("Welcome to the query plan exporter. Target: %s.\n", *target)
 
-	pgScanner := pgscanner.New(os.Stdin, os.Stdout, planner)
+	scannerCfg := &pgscanner.Config{
+		AutoConfirm: *autoConfirm,
+	}
+
+	pgScanner := pgscanner.New(scannerCfg, os.Stdin, os.Stdout, planner)
 	pgScanner.Run(ctx)
 }

--- a/pgscanner/pgscanner_test.go
+++ b/pgscanner/pgscanner_test.go
@@ -18,7 +18,7 @@ func (m Mock) Export(s string) (string, error) {
 func TestSuccessfulPlanPosting(t *testing.T) {
 	buf := &bytes.Buffer{}
 
-	pgScanner := New(buf, buf, &Mock{url: "testURL"})
+	pgScanner := New(&Config{}, buf, buf, &Mock{url: "testURL"})
 	pgScanner.state.SetBuffer("non-empty buffer")
 	pgScanner.state.SetMode(ConfirmingMode)
 
@@ -27,7 +27,8 @@ func TestSuccessfulPlanPosting(t *testing.T) {
 	actualResult := buf.String()
 	expectedResult := `Posting to the visualizer...
 The plan has been posted successfully.
-URL: testURL`
+URL: testURL
+`
 
 	if actualResult != expectedResult {
 		t.Errorf("failed to post a plan. Given result: %s", actualResult)
@@ -45,7 +46,7 @@ URL: testURL`
 func TestPlanPostingWithEmptyBuffer(t *testing.T) {
 	buf := &bytes.Buffer{}
 
-	pgScanner := New(buf, buf, &Mock{url: "testURL"})
+	pgScanner := New(&Config{}, buf, buf, &Mock{url: "testURL"})
 	pgScanner.state.SetMode(ConfirmingMode)
 
 	pgScanner.postPlan()
@@ -70,7 +71,7 @@ no plan to export
 func TestPlanPostingWithWrongMode(t *testing.T) {
 	buf := &bytes.Buffer{}
 
-	pgScanner := New(buf, buf, &Mock{url: "testURL"})
+	pgScanner := New(&Config{}, buf, buf, &Mock{url: "testURL"})
 	pgScanner.state.SetBuffer("non-empty buffer")
 
 	pgScanner.postPlan()
@@ -95,7 +96,7 @@ cannot post because scanner is in invalid mode
 func TestPlanPostingWithFailedExport(t *testing.T) {
 	buf := &bytes.Buffer{}
 
-	pgScanner := New(buf, buf, &Mock{url: "testURL", err: errors.New("failed export")})
+	pgScanner := New(&Config{}, buf, buf, &Mock{url: "testURL", err: errors.New("failed export")})
 	pgScanner.state.SetBuffer("non-empty buffer")
 	pgScanner.state.SetMode(ConfirmingMode)
 


### PR DESCRIPTION
Feature request https://github.com/agneum/plan-exporter/issues/11

Send an execution plan automatically without additional confirmation. The option allows using `plan-exporter` outside `psql`. 
For example,
  ```bash
  psql -f my_explain_file.sql | plan-exporter --target=dalibo --auto-confirm
  ``` 
