### PR TITLE
feat: add a target URL to welcome message (#13)

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/agneum/plan-exporter/config"
 	"github.com/agneum/plan-exporter/pgscanner"
@@ -21,18 +20,16 @@ func main() {
 	flag.Parse()
 
 	ctx := context.Background()
-	cfg := &config.Config{
+	planner, err := visualizer.New(&config.Config{
 		Target:  *target,
 		PostURL: *postURL,
-	}
-
-	planner, err := visualizer.New(cfg)
+	})
 
 	if err != nil {
 		log.Fatalf("failed to init a query plan exporter: %v", err)
 	}
 
-	fmt.Println(generateWelcomeMessage(cfg, planner))
+	fmt.Println(generateWelcomeMessage(planner))
 
 	scannerCfg := &pgscanner.Config{
 		AutoConfirm: *autoConfirm,
@@ -42,12 +39,6 @@ func main() {
 	pgScanner.Run(ctx)
 }
 
-func generateWelcomeMessage(cfg *config.Config, planner pgscanner.PlanExporter) string {
-	welcome := strings.Builder{}
-
-	welcome.WriteString("Welcome to the query plan exporter.")
-	welcome.WriteString(fmt.Sprintf("\nTarget: %s", cfg.Target))
-	welcome.WriteString(fmt.Sprintf("\nURL: %s", planner.Target()))
-
-	return welcome.String()
+func generateWelcomeMessage(planner pgscanner.PlanExporter) string {
+	return fmt.Sprintf("Welcome to the query plan exporter.\nURL: %s", planner.Target())
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/agneum/plan-exporter/config"
 	"github.com/agneum/plan-exporter/pgscanner"
@@ -20,16 +21,18 @@ func main() {
 	flag.Parse()
 
 	ctx := context.Background()
-	planner, err := visualizer.New(&config.Config{
+	cfg := &config.Config{
 		Target:  *target,
 		PostURL: *postURL,
-	})
+	}
+
+	planner, err := visualizer.New(cfg)
 
 	if err != nil {
 		log.Fatalf("failed to init a query plan exporter: %v", err)
 	}
 
-	fmt.Printf("Welcome to the query plan exporter. Target: %s.\n", *target)
+	fmt.Println(generateWelcomeMessage(cfg, planner))
 
 	scannerCfg := &pgscanner.Config{
 		AutoConfirm: *autoConfirm,
@@ -37,4 +40,14 @@ func main() {
 
 	pgScanner := pgscanner.New(scannerCfg, os.Stdin, os.Stdout, planner)
 	pgScanner.Run(ctx)
+}
+
+func generateWelcomeMessage(cfg *config.Config, planner pgscanner.PlanExporter) string {
+	welcome := strings.Builder{}
+
+	welcome.WriteString("Welcome to the query plan exporter.")
+	welcome.WriteString(fmt.Sprintf("\nTarget: %s", cfg.Target))
+	welcome.WriteString(fmt.Sprintf("\nURL: %s", planner.Target()))
+
+	return welcome.String()
 }

--- a/pgscanner/pgscanner.go
+++ b/pgscanner/pgscanner.go
@@ -22,6 +22,7 @@ const confirmationResponse = "Y"
 // PlanExporter defines the interface to post query plans.
 type PlanExporter interface {
 	Export(string) (string, error)
+	Target() string
 }
 
 // PgScanner provides a psql output scanner.

--- a/pgscanner/pgscanner_test.go
+++ b/pgscanner/pgscanner_test.go
@@ -15,6 +15,10 @@ func (m Mock) Export(s string) (string, error) {
 	return m.url, m.err
 }
 
+func (m Mock) Target() string {
+	return m.url
+}
+
 func TestSuccessfulPlanPosting(t *testing.T) {
 	buf := &bytes.Buffer{}
 

--- a/visualizer/dalibo/dalibo.go
+++ b/visualizer/dalibo/dalibo.go
@@ -40,3 +40,8 @@ func (d *Dalibo) Export(plan string) (string, error) {
 
 	return explainURL, nil
 }
+
+// Target returns a post URL.
+func (d *Dalibo) Target() string {
+	return d.postURL
+}

--- a/visualizer/dalibo/dalibo.go
+++ b/visualizer/dalibo/dalibo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/agneum/plan-exporter/client"
 )
 
-// visualizer constants
+// Visualizer constants.
 const (
 	VisualizerType = "dalibo"
 	defaultPostURL = "https://explain.dalibo.com/new"

--- a/visualizer/depesz/depesz.go
+++ b/visualizer/depesz/depesz.go
@@ -40,3 +40,8 @@ func (d *Depesz) Export(plan string) (string, error) {
 
 	return explainURL, nil
 }
+
+// Target returns a post URL.
+func (d *Depesz) Target() string {
+	return d.postURL
+}

--- a/visualizer/depesz/depesz.go
+++ b/visualizer/depesz/depesz.go
@@ -8,7 +8,7 @@ import (
 	"github.com/agneum/plan-exporter/client"
 )
 
-// visualizer constants
+// Visualizer constants.
 const (
 	VisualizerType = "depesz"
 	defaultPostURL = "https://explain.depesz.com/"

--- a/visualizer/tensor/tensor.go
+++ b/visualizer/tensor/tensor.go
@@ -30,13 +30,18 @@ func New(postURL string) *Tensor {
 }
 
 // Export posts plan to a visualizer and returns link to the visualization plan page.
-func (d *Tensor) Export(plan string) (string, error) {
+func (t *Tensor) Export(plan string) (string, error) {
 	formVal := url.Values{planKey: []string{plan}}
 
-	explainURL, err := client.MakeRequest(d.postURL, formVal)
+	explainURL, err := client.MakeRequest(t.postURL, formVal)
 	if err != nil {
 		return "", fmt.Errorf("failed to make a request: %w", err)
 	}
 
 	return explainURL, nil
+}
+
+// Target returns a post URL.
+func (t *Tensor) Target() string {
+	return t.postURL
 }

--- a/visualizer/tensor/tensor.go
+++ b/visualizer/tensor/tensor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/agneum/plan-exporter/client"
 )
 
-// visualizer constants
+// Visualizer constants.
 const (
 	VisualizerType = "tensor"
 	defaultPostURL = "https://explain.tensor.ru/explain"


### PR DESCRIPTION
Extend the welcome message and show the `post-url` there.
Close #13 