### PR TITLE
fix: adjust API protocols

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,11 +3,12 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 )
 
-// MakeRequest performs the request and returns the redirected request URL.
+// MakeRequest performs request and returns the redirected request URL.
 func MakeRequest(targetURL string, formVal url.Values) (string, error) {
 	response, err := http.PostForm(targetURL, formVal) // nolint:gosec
 	if err != nil {
@@ -19,4 +20,14 @@ func MakeRequest(targetURL string, formVal url.Values) (string, error) {
 	}
 
 	return response.Request.URL.String(), nil
+}
+
+// MakeRequestWithBody performs request and returns response.
+func MakeRequestWithBody(targetURL string, formVal url.Values) (io.ReadCloser, error) {
+	response, err := http.PostForm(targetURL, formVal) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to post form: %w", err)
+	}
+
+	return response.Body, nil
 }

--- a/visualizer/dalibo/dalibo.go
+++ b/visualizer/dalibo/dalibo.go
@@ -2,22 +2,37 @@
 package dalibo
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/agneum/plan-exporter/client"
 )
 
 // Visualizer constants.
 const (
-	VisualizerType = "dalibo"
-	defaultPostURL = "https://explain.dalibo.com/new"
-	planKey        = "plan"
+	VisualizerType    = "dalibo"
+	defaultPostURL    = "https://explain.dalibo.com"
+	newPlanRoute      = "new.json"
+	planResponseRoute = "plan"
+
+	planKey  = "plan"
+	titleKey = "title"
+	queryKey = "query"
 )
 
 // Dalibo defines a query plan exporter for the Dalibo visualizer.
 type Dalibo struct {
 	postURL string
+}
+
+// PlanResponse represents response body.
+type PlanResponse struct {
+	ID        string `json:"id"`
+	DeleteKey string `json:"deleteKey"`
 }
 
 // New creates a new Dalibo exporter.
@@ -26,22 +41,54 @@ func New(postURL string) *Dalibo {
 		postURL = defaultPostURL
 	}
 
-	return &Dalibo{postURL: postURL}
-}
-
-// Export posts plan to a visualizer and returns link to the visualization plan page.
-func (d *Dalibo) Export(plan string) (string, error) {
-	formVal := url.Values{planKey: []string{plan}}
-
-	explainURL, err := client.MakeRequest(d.postURL, formVal)
-	if err != nil {
-		return "", fmt.Errorf("failed to make a request: %w", err)
+	return &Dalibo{
+		postURL: postURL,
 	}
-
-	return explainURL, nil
 }
 
 // Target returns a post URL.
 func (d *Dalibo) Target() string {
 	return d.postURL
+}
+
+// Export posts plan to a visualizer and returns link to the visualization plan page.
+func (d *Dalibo) Export(plan string) (string, error) {
+	formVal := url.Values{
+		planKey:  []string{strings.TrimSpace(plan)},
+		titleKey: []string{fmt.Sprintf("Plan created on %s", time.Now().Format(time.RFC1123))},
+		queryKey: []string{""},
+	}
+
+	requestURL, err := url.JoinPath(d.postURL, newPlanRoute)
+	if err != nil {
+		return "", fmt.Errorf("failed to build request URL: %w", err)
+	}
+
+	planBody, err := client.MakeRequestWithBody(requestURL, formVal)
+	if err != nil {
+		return "", fmt.Errorf("failed to build request URL: %w", err)
+	}
+
+	defer func() { _ = planBody.Close() }()
+
+	planResponse, err := d.parseBody(planBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to make a request: %w", err)
+	}
+
+	return d.buildShareLink(planResponse.ID)
+}
+
+func (d *Dalibo) parseBody(body io.ReadCloser) (*PlanResponse, error) {
+	var plan PlanResponse
+
+	if err := json.NewDecoder(body).Decode(&plan); err != nil {
+		return nil, err
+	}
+
+	return &plan, nil
+}
+
+func (d *Dalibo) buildShareLink(id string) (string, error) {
+	return url.JoinPath(d.postURL, planResponseRoute, id)
 }

--- a/visualizer/tensor/tensor.go
+++ b/visualizer/tensor/tensor.go
@@ -12,7 +12,7 @@ import (
 const (
 	VisualizerType = "tensor"
 	defaultPostURL = "https://explain.tensor.ru/explain"
-	planKey        = "explain"
+	planKey        = "plan"
 )
 
 // Tensor defines a query plan exporter for the Tensor visualizer.


### PR DESCRIPTION
Plan exporter should be modified since API protocols have been changed:
- Dalibo: ignore HTTP redirections, read and parse response body to build a plan link
- Tensor: rename the `plan` field